### PR TITLE
Add the Dyalog .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Windows line endings: diaf
+* text=auto eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.jpg binary
+*.png binary
+*.gif binary
+*.apl? linguist-language=APL


### PR DESCRIPTION
Add a .gitattributes file so that syntax highlighting works, and that we protect ourselves against incompatible line endings.