### PR TITLE
Minor chages to Sample*.aplf examples.

### DIFF
--- a/aplsource/Sample.aplf
+++ b/aplsource/Sample.aplf
@@ -20,7 +20,7 @@
 
  consumer.set_topic_partition l'animals'
  consumer.subscribe_topic_partition l
-
+ ⎕DL 5
 
 
  bb←⎕NEW #.Record('animals' 'Blackbird' 'birds')

--- a/aplsource/Sample2.aplf
+++ b/aplsource/Sample2.aplf
@@ -23,8 +23,9 @@
 
  l←consumer.topic_partition
  consumer.set_topic_partition l'animals'
- ⍝consumer.set_topic_partition l'cars'
+ consumer.set_topic_partition l'cars'
  consumer.subscribe_topic_partition l
+ ⎕DL 5
 
  producer←⎕NEW Producer
  producer.configure'bootstrap.servers' 'localhost:9092'⍝'grs3550.insight.local:9092'
@@ -38,7 +39,7 @@
      :EndIf
  :EndFor
 
- ⍝producer.produce_record ⎕NEW #.Record('cars' 'ferrari' 'sportcars')
+ producer.produce_record ⎕NEW #.Record('cars' 'ferrari' 'sportcars')
  producer.update_outstanding
 
  start←3⊃⎕AI

--- a/aplsource/Sample3.aplf
+++ b/aplsource/Sample3.aplf
@@ -26,8 +26,8 @@
  config⍪←'group.id' 'dyalog'
 
  consumer←⎕NEW Consumer config
-
  consumer.subscribe'animals' 'cars' 'plants'
+ ⎕DL 5
 
  config←0 2⍴⍬
  config⍪←'bootstrap.servers' 'localhost:9092'

--- a/aplsource/Sample4.aplf
+++ b/aplsource/Sample4.aplf
@@ -28,6 +28,7 @@
  topic_list←'animals' 'cars' 'plants'
 
  consumer←⎕NEW Consumer(config topic_list)
+ ⎕DL 5
 
  config←0 2⍴⍬
  config⍪←'bootstrap.servers' 'localhost:9092'


### PR DESCRIPTION
Added ⎕DL 5 in Samples to allow the consumer to subscribe and get ready before consume.