### PR TITLE
Fixing problem with zero term error texts

### DIFF
--- a/aplsource/kafka/consume.aplf
+++ b/aplsource/kafka/consume.aplf
@@ -1,18 +1,18 @@
- r←consume(cons tl pl kl)
+ r←consume(cons tl pl kl);err;topic;tlen;pay;paylen;key;keylen;part;msg;len
  ⍝ Consume the next message
  ⍝ cons the consumer instance
  ⍝ tl topic lenght
  ⍝ pl payload length
  ⍝ kl key length
 
- r←Consume cons tl tl pl pl kl kl 1 512 512
- :Select ⊃r
+ (err topic tlen pay paylen key keylen part msg len)←10↑Consume cons tl tl pl pl kl kl 1 512 512
+ :Select err
  :Case 0   ⍝ we got a message
-     r←0,(r[3 5 7]↑¨r[2 4 6]),8⊃r
+     r←0 (tlen↑topic) (paylen↑pay) (keylen↑key) part
  :Case 1   ⍝ no message
-     r←r[1 9]
+     r←err (len↑msg)
  :Case 2   ⍝ we are need more space
-     r←consume 10+r[3 5 7]
+     r←consume cons,(10+tlen paylen keylen)
  :Else    ⍝ Kafka error
-     r←r[1 9]
+     r←err (len↑msg)
  :EndSelect

--- a/aplsource/kafka/errormsg.aplf
+++ b/aplsource/kafka/errormsg.aplf
@@ -1,4 +1,5 @@
- r←errormsg errid
+ r←errormsg errid;len;msg;err
  ⍝ get the text for an error number
  ⍝ errid  error  number
- r←DRMessageError errid 512 512
+ (err msg len)←3↑DRMessageError errid 512 512
+  r←err (len↑msg)

--- a/aplsource/kafka/produce.aplf
+++ b/aplsource/kafka/produce.aplf
@@ -1,8 +1,13 @@
- r←produce(prod topic_name payload key partition)
+ r←produce(prod topic_name payload key partition);err;msgid;msg;len
  ⍝ Produce a messages to the kafka server
  ⍝ prod porducer instance
  ⍝ topic_name topic name
  ⍝ payload payload
  ⍝ key key
  ⍝ partition partition
- r←Produce prod topic_name payload(≢payload)key(≢key)partition 1 512 512
+ (err msgid msg len)←Produce prod topic_name payload(≢payload)key(≢key)partition 1 512 512
+ :if 0≠err
+    r←err msgid (len↑msg)
+ :else
+    r←0 msgid ''
+:endif

--- a/aplsource/kafka/produce.aplf
+++ b/aplsource/kafka/produce.aplf
@@ -5,7 +5,7 @@
  ⍝ payload payload
  ⍝ key key
  ⍝ partition partition
- (err msgid msg len)←Produce prod topic_name payload(≢payload)key(≢key)partition 1 512 512
+ (err msgid msg len)←4↑Produce prod topic_name payload(≢payload)key(≢key)partition 1 512 512
  :if 0≠err
     r←err msgid (len↑msg)
  :else

--- a/aplsource/kafka/setconf.aplf
+++ b/aplsource/kafka/setconf.aplf
@@ -1,12 +1,12 @@
- r←setconf(inst opt val)
+ r←setconf(inst opt val);err;msg;len
 ⍝ set an option for a kafka instance
 ⍝ inst the kafka instance could be either Producer or Consumer
 ⍝ opt  option
 ⍝ val   value
 
- r←SetKafkaConf inst opt val 512 512
- :If 0≠⊃r
-     r←r
+ (err msg len)←3↑SetKafkaConf inst opt val 512 512
+ :If 0≠err
+     r←err  (len↑msg)
  :Else
      r←0 ''
  :EndIf

--- a/aplsource/kafka/subscribe_topic_partition.aplf
+++ b/aplsource/kafka/subscribe_topic_partition.aplf
@@ -1,11 +1,11 @@
- r←subscribe_topic_partition(cons topic_partition_list)
+ r←subscribe_topic_partition(cons topic_partition_list);err;msg;len
  ⍝ Subscribe to a list of topics
 ⍝ cons Instance of a COnsumer
 ⍝ topic_partition_list list of topics
 
- r←SubscribeConsumerTPList cons topic_partition_list 512 512
- :If 0≠⊃r
-     r←r
+ (err msg len)←3↑SubscribeConsumerTPList cons topic_partition_list 512 512
+ :If 0≠err
+     r←err (len↑msg)
  :Else
      r←0 ''
  :EndIf

--- a/kafka/kafka.h
+++ b/kafka/kafka.h
@@ -37,22 +37,22 @@ extern "C"
 	LIBRARY_API int UninitProducer(void* prod);
 	LIBRARY_API int UninitConsumer(void* cons);
 
-	LIBRARY_API int SetKafkaConf(void* kafka, char* key, char* val, char* errtxt, int len);
+	LIBRARY_API int SetKafkaConf(void* kafka, char* key, char* val, char* errtxt, int *plen);
 
 	LIBRARY_API int NewTopicConf(void** topicconf);
 	LIBRARY_API int DelTopicConf(void* topicconf);
-	LIBRARY_API int SetTopicConf(void* topicconf, char* key, char* val, char* errtxt, int len);
+	LIBRARY_API int SetTopicConf(void* topicconf, char* key, char* val, char* errtxt, int *plen);
 
 	//LIBRARY_API int CreateTopic(void** topic, void* kafka, char* topic_name, void* topic_conf);
 	LIBRARY_API int NewTopicPartitionList(void** subscr);
 	LIBRARY_API int SetTopicPartitionList(void* subscr, char* topic);
 	
-	LIBRARY_API int SubscribeConsumerTPList(void* kafka, void* subscr, char* errtxt, int len);
-	LIBRARY_API int Produce(void* prod, char* topic, char* payload, uint32_t paylen, char* key, uint32_t keylen, int32_t partition, uint64_t* msgid, char* errtxt, int len);
+	LIBRARY_API int SubscribeConsumerTPList(void* kafka, void* subscr, char* errtxt, int *plen);
+	LIBRARY_API int Produce(void* prod, char* topic, char* payload, uint32_t paylen, char* key, uint32_t keylen, int32_t partition, uint64_t* msgid, char* errtxt, int *plen);
 
-	LIBRARY_API int Consume(void* cons, char* topic, uint32_t* topiclen, char* payload, uint32_t* paylen, char* key, uint32_t* keylen, int32_t* partition, char* errtxt, int len);
+	LIBRARY_API int Consume(void* cons, char* topic, uint32_t* topiclen, char* payload, uint32_t* paylen, char* key, uint32_t* keylen, int32_t* partition, char* errtxt, int *plen);
 
 	LIBRARY_API int DeliveryReport(void* prod, unsigned long long* msgid, int* err, int* plength);
-	LIBRARY_API int DRMessageError(int* err, char* errtxt, int length);
+	LIBRARY_API int DRMessageError(int* err, char* errtxt, int *plen);
 	// Do we need these?
 }


### PR DESCRIPTION
I have change the limit on the error text to be limit on the call and actual length on the return. And I have updated the apl function to reflect that

I have left the Topic, Key and payload unchanged since we are using APL both and the producing and consuming end to handle the number of bytes, no matter it is text or binary. 