### PR TITLE
14 commit offsets

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -117,12 +117,17 @@ Assumption: you have created a configuration table as per above.
     ```
 3. Consume
 
-    Consume messages in a loop. Kafka parallelism is achieved by consumer groups and partitioned topics. The `Record` interface allow for access by the names `Topic`, `Payload`, `Key`, `Partition`.
+    Consume messages in a loop. Kafka parallelism is achieved by consumer groups and partitioned topics. The `Record` interface allow for access by the names `Topic`, `Payload`, `Key`, `Partition`, `Offset`.
     ```apl
     :While 0=⊃rec←consumer.consume_record
-        (2⊃rec).(Topic Payload Key Partition)
+        (2⊃rec).(Topic Payload Key Partition Offset)
     :EndWhile
     ```
+    If auto-commit is disabled (see the `enable.auto.commit` config parameter for the consumer), it is possible to manually commit offsets
+    ```apl
+    consumer.commit 
+    ```
+    which will synchronously commit the offset on the current partition assignment.
 4. Destroy consumer
     ```apl
     ⎕EX'consumer'

--- a/aplsource/Consumer.aplc
+++ b/aplsource/Consumer.aplc
@@ -60,9 +60,14 @@
       r←kafka.new_topic_partition
     ∇
 
-    ∇ r←set_topic_partition(topic_partition_list topicname)
+    ∇ r←set_topic_partition(topic_partition_list topicname partition)
       :Access public
-      r←kafka.set_topic_partition topic_partition_list topicname
+      r←kafka.set_topic_partition topic_partition_list topicname partition
+    ∇
+
+    ∇ r←set_offset(topic_partition_list topicname partition offset)
+      :Access public
+      r←kafka.set_offset topic_partition_list topicname partition offset
     ∇
 
     ∇ r←subscribe_topic_partition topic_partition_list
@@ -75,7 +80,7 @@
       
       :If 0≠≢topic_list
           topic_partition_list←topic_partition
-          set_topic_partition¨ topic_partition_list,¨⊂¨(,⊆topic_list)~⊂''
+          set_topic_partition¨((topic_partition_list,¨⊂¨(,⊆topic_list)~⊂''),¨⊂0)
           r←subscribe_topic_partition topic_partition_list
       :Else
       ⍝ Throw error   
@@ -97,9 +102,9 @@
       :EndIf
     ∇  
     
-    ∇ r←commit asynch
+    ∇ r←commit(tplist asynch)
       :Access public
-      r←kafka.commit cons asynch
+      r←kafka.commit cons tplist asynch
     ∇
 
     ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝

--- a/aplsource/Consumer.aplc
+++ b/aplsource/Consumer.aplc
@@ -104,7 +104,7 @@
     
     ∇ r←commit
       :Access public
-      r←kafka.commit cons 0 0
+      r←kafka.commit cons 0
     ∇
 
     ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝

--- a/aplsource/Consumer.aplc
+++ b/aplsource/Consumer.aplc
@@ -102,9 +102,9 @@
       :EndIf
     ∇  
     
-    ∇ r←commit(tplist asynch)
+    ∇ r←commit
       :Access public
-      r←kafka.commit cons tplist asynch
+      r←kafka.commit cons 0 0
     ∇
 
     ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝

--- a/aplsource/Consumer.aplc
+++ b/aplsource/Consumer.aplc
@@ -95,6 +95,11 @@
       :If 0=⊃r
           r←0(⎕NEW #.Record(r[2 3 4 5]))
       :EndIf
+    ∇  
+    
+    ∇ r←commit asynch
+      :Access public
+      r←kafka.commit cons asynch
     ∇
 
     ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝

--- a/aplsource/Consumer.aplc
+++ b/aplsource/Consumer.aplc
@@ -98,7 +98,7 @@
       :Access public
       r←kafka.consume cons 200 2048 200
       :If 0=⊃r
-          r←0(⎕NEW #.Record(r[2 3 4 5]))
+          r←0(⎕NEW #.Record(r[2 3 4 5 6]))
       :EndIf
     ∇  
     

--- a/aplsource/Record.aplc
+++ b/aplsource/Record.aplc
@@ -3,13 +3,14 @@
 :field Public Payload
 :field Public Key
 :field Public Partition 
-
+:field Public Offset
 
 ∇Clear
 Topic←''
 Payload←''
 Key←''
 Partition←¯1
+Offset←¯1
 ∇           
 
 ∇Make
@@ -52,6 +53,15 @@ Key←key
 Partition←partition
 ∇
 
+∇Make5 (topic payload key partition offset)
+:access public
+:implements constructor
+Topic←topic
+Payload←payload
+Key←key
+Partition←partition
+Offset←offset
+∇
  
 
 ∇r←asArg

--- a/aplsource/kafka/commit.aplf
+++ b/aplsource/kafka/commit.aplf
@@ -1,0 +1,2 @@
+ r←commit(cons asynch)
+ r←Commit cons 0 asynch

--- a/aplsource/kafka/commit.aplf
+++ b/aplsource/kafka/commit.aplf
@@ -1,2 +1,2 @@
- r←commit(cons asynch)
- r←Commit cons 0 asynch
+ r←commit(cons tplist asynch)
+ r←Commit cons tplist asynch

--- a/aplsource/kafka/commit.aplf
+++ b/aplsource/kafka/commit.aplf
@@ -1,2 +1,2 @@
- r←commit(cons tplist asynch)
- r←Commit cons tplist asynch
+ r←commit(cons tplist)
+ r←Commit cons tplist

--- a/aplsource/kafka/consume.aplf
+++ b/aplsource/kafka/consume.aplf
@@ -1,14 +1,14 @@
- r←consume(cons tl pl kl);err;topic;tlen;pay;paylen;key;keylen;part;msg;len
+ r←consume(cons tl pl kl);err;topic;tlen;pay;paylen;key;keylen;part;offset;msg;len
  ⍝ Consume the next message
  ⍝ cons the consumer instance
  ⍝ tl topic lenght
  ⍝ pl payload length
  ⍝ kl key length
 
- (err topic tlen pay paylen key keylen part msg len)←10↑Consume cons tl tl pl pl kl kl 1 512 512
+ (err topic tlen pay paylen key keylen part offset msg len)←11↑Consume cons tl tl pl pl kl kl 1 1 512 512
  :Select err
  :Case 0   ⍝ we got a message
-     r←0 (tlen↑topic) (paylen↑pay) (keylen↑key) part
+     r←0 (tlen↑topic) (paylen↑pay) (keylen↑key) part offset
  :Case 1   ⍝ no message
      r←err (len↑msg)
  :Case 2   ⍝ we are need more space

--- a/aplsource/kafka/set_offset.aplf
+++ b/aplsource/kafka/set_offset.aplf
@@ -1,8 +1,8 @@
- r←set_topic_partition(topic_partition_list topicname partition)
+ r←set_offset(topic_partition_list topicname partition offset)
  ⍝ Add a topic to a topiclist
  ⍝ topic_partition_list topic partition list
  ⍝ topicname the topic to add to the list
- r←SetTopicPartitionList topic_partition_list topicname partition
+ r←SetOffset topic_partition_list topicname partition offset
  :If 0≠⊃r
      r←r
  :Else

--- a/kafka/kafka.cpp
+++ b/kafka/kafka.cpp
@@ -203,9 +203,7 @@ LIBRARY_API int SetTopicPartitionList(void* subscr, char* topic, int32_t partiti
 {
 
 	rd_kafka_topic_partition_list_t* subscription = (rd_kafka_topic_partition_list_t*)subscr;
-	rd_kafka_topic_partition_list_add(subscription, 
-								     (const char*)topic, 
-									  partition);
+	rd_kafka_topic_partition_list_add(subscription, (const char*)topic, partition);
 
 	return 0;
 }
@@ -214,10 +212,7 @@ LIBRARY_API int SetOffset(void* subscr, char* topic, int32_t partition, int64_t 
 {
 	rd_kafka_resp_err_t res;
 	rd_kafka_topic_partition_list_t* subscription = (rd_kafka_topic_partition_list_t*)subscr;
-	res = rd_kafka_topic_partition_list_set_offset(subscription, 
-													(const char*) topic, 
-													partition, 
-													offset);
+	res = rd_kafka_topic_partition_list_set_offset(subscription, (const char*) topic, partition, offset);
 
 	return (int)res;
 }
@@ -316,10 +311,7 @@ LIBRARY_API int Commit(void* cons, void* subscr, int32_t async)
 	rd_kafka_topic_partition_list_t* offsets = (rd_kafka_topic_partition_list_t*)subscr;
 	rd_kafka_resp_err_t res;
 
-	res = rd_kafka_commit(rk,
-						  offsets,
-						  async
-		  );
+	res = rd_kafka_commit(rk, offsets, async);
 	
 	return (int) res;
 }

--- a/kafka/kafka.cpp
+++ b/kafka/kafka.cpp
@@ -294,7 +294,25 @@ LIBRARY_API int Consume(void* cons, char* topic,uint32_t *topiclen, char* payloa
 	}
 	return 0;
 }
+LIBRARY_API int Commit(void* cons, void* subscr, int* async) 
+{
+	kafka_struct* co = (kafka_struct*)cons;
+	rd_kafka_t* rk = (rd_kafka_t*)co->rk;
+	rd_kafka_topic_partition_list_t* offsets = (rd_kafka_topic_partition_list_t*)subscr;
+	rd_kafka_resp_err_t res;
 
+/*	rd_kafka_resp_err_t res_committed = rd_kafka_committed(rk,
+													       offsets,
+														   10
+										);
+	offsets->elems->offset = offsets->elems->offset + 1;*/
+	res = rd_kafka_commit(rk,
+						  offsets,
+						  (int) async
+		  );
+	
+	return (int) res;
+}
 
 
 LIBRARY_API int DeliveryReport(void* prod, unsigned long long* msgid, int* err, int* plength)
@@ -408,6 +426,7 @@ LIBRARY_API int32_t Describe(char* buffer, int32_t* psize)
 	Add(buffer, "\"I4 %P|SetTopicPartitionList P <0T1\",", &off, *psize);
 	Add(buffer, "\"I4 %P|SubscribeConsumerTPList P P >0T1 =I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|Consume P >0T1 =U4 >0T1 =U4 >0T1 =U4 >U4 >0T1 =I4\",", &off, *psize);
+	Add(buffer, "\"I4 %P|Commit P P <I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|Produce P <0T1 <0T1 U4 <0T1 U4 I4 >U8 >0T1 =I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|DeliveryReport P >I8[] >I4[] =I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|DRMessageError <I4 >0T1 =I4\"", &off, *psize);

--- a/kafka/kafka.cpp
+++ b/kafka/kafka.cpp
@@ -304,14 +304,15 @@ LIBRARY_API int Consume(void* cons, char* topic,uint32_t *topiclen, char* payloa
 	return 0;
 }
 
-LIBRARY_API int Commit(void* cons, void* subscr, int32_t async)
+LIBRARY_API int Commit(void* cons, void* subscr)
 {
 	kafka_struct* co = (kafka_struct*)cons;
 	rd_kafka_t* rk = (rd_kafka_t*)co->rk;
 	rd_kafka_topic_partition_list_t* offsets = (rd_kafka_topic_partition_list_t*)subscr;
 	rd_kafka_resp_err_t res;
 
-	res = rd_kafka_commit(rk, offsets, async);
+	// Allow only sync
+	res = rd_kafka_commit(rk, offsets, 0);
 	
 	return (int) res;
 }
@@ -429,7 +430,7 @@ LIBRARY_API int32_t Describe(char* buffer, int32_t* psize)
 	Add(buffer, "\"I4 %P|SetOffset P <0T1 I4 I8\",", &off, *psize);
 	Add(buffer, "\"I4 %P|SubscribeConsumerTPList P P >0T1 =I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|Consume P >0T1 =U4 >0T1 =U4 >0T1 =U4 >U4 >0T1 =I4\",", &off, *psize);
-	Add(buffer, "\"I4 %P|Commit P P I4\",", &off, *psize);
+	Add(buffer, "\"I4 %P|Commit P P\",", &off, *psize);
 	Add(buffer, "\"I4 %P|Produce P <0T1 <0T1 U4 <0T1 U4 I4 >U8 >0T1 =I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|DeliveryReport P >I8[] >I4[] =I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|DRMessageError <I4 >0T1 =I4\"", &off, *psize);

--- a/kafka/kafka.cpp
+++ b/kafka/kafka.cpp
@@ -244,7 +244,7 @@ LIBRARY_API int SubscribeConsumerTPList(void* kafka, void* subscr, char* errtxt,
 }
 
 
-LIBRARY_API int Consume(void* cons, char* topic,uint32_t *topiclen, char* payload,uint32_t *paylen,char* key, uint32_t *keylen,int32_t *partition,  char* errtxt, int *plen)
+LIBRARY_API int Consume(void* cons, char* topic,uint32_t *topiclen, char* payload,uint32_t *paylen,char* key, uint32_t *keylen,int32_t *partition, int64_t* offset,  char* errtxt, int *plen)
 {
 	kafka_struct* co = (kafka_struct*)cons;
 	rd_kafka_message_t* rkmessage;
@@ -288,6 +288,7 @@ LIBRARY_API int Consume(void* cons, char* topic,uint32_t *topiclen, char* payloa
 //		strncpy_s(payload, *paylen, (char*)rkmessage->payload, rkmessage->len);
 //		strncpy_s(key, *keylen,(char*) rkmessage->key, rkmessage->key_len);
 		*partition = rkmessage->partition;
+		*offset = (int64_t)rkmessage->offset;
 
 		*topiclen = (uint32_t)tlen;
 		*paylen = (uint32_t)rkmessage->len;
@@ -429,7 +430,7 @@ LIBRARY_API int32_t Describe(char* buffer, int32_t* psize)
 	Add(buffer, "\"I4 %P|SetTopicPartitionList P <0T1 I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|SetOffset P <0T1 I4 I8\",", &off, *psize);
 	Add(buffer, "\"I4 %P|SubscribeConsumerTPList P P >0T1 =I4\",", &off, *psize);
-	Add(buffer, "\"I4 %P|Consume P >0T1 =U4 >0T1 =U4 >0T1 =U4 >U4 >0T1 =I4\",", &off, *psize);
+	Add(buffer, "\"I4 %P|Consume P >0T1 =U4 >0T1 =U4 >0T1 =U4 >U4 >I8 >0T1 =I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|Commit P P\",", &off, *psize);
 	Add(buffer, "\"I4 %P|Produce P <0T1 <0T1 U4 <0T1 U4 I4 >U8 >0T1 =I4\",", &off, *psize);
 	Add(buffer, "\"I4 %P|DeliveryReport P >I8[] >I4[] =I4\",", &off, *psize);

--- a/kafka/kafka.h
+++ b/kafka/kafka.h
@@ -51,7 +51,7 @@ extern "C"
 	LIBRARY_API int SubscribeConsumerTPList(void* kafka, void* subscr, char* errtxt, int *plen);
 	LIBRARY_API int Produce(void* prod, char* topic, char* payload, uint32_t paylen, char* key, uint32_t keylen, int32_t partition, uint64_t* msgid, char* errtxt, int *plen);
 
-	LIBRARY_API int Consume(void* cons, char* topic, uint32_t* topiclen, char* payload, uint32_t* paylen, char* key, uint32_t* keylen, int32_t* partition, char* errtxt, int *plen);
+	LIBRARY_API int Consume(void* cons, char* topic, uint32_t* topiclen, char* payload, uint32_t* paylen, char* key, uint32_t* keylen, int32_t* partition, int64_t* offset, char* errtxt, int *plen);
 	LIBRARY_API int Commit(void* cons, void* subscr);
 
 	LIBRARY_API int DeliveryReport(void* prod, unsigned long long* msgid, int* err, int* plength);

--- a/kafka/kafka.h
+++ b/kafka/kafka.h
@@ -45,13 +45,14 @@ extern "C"
 
 	//LIBRARY_API int CreateTopic(void** topic, void* kafka, char* topic_name, void* topic_conf);
 	LIBRARY_API int NewTopicPartitionList(void** subscr);
-	LIBRARY_API int SetTopicPartitionList(void* subscr, char* topic);
-	
+	LIBRARY_API int SetTopicPartitionList(void* subscr, char* topic, int32_t partition);
+	LIBRARY_API int SetOffset(void* subscr, char* topic, int32_t partition, int64_t offset);
+
 	LIBRARY_API int SubscribeConsumerTPList(void* kafka, void* subscr, char* errtxt, int *plen);
 	LIBRARY_API int Produce(void* prod, char* topic, char* payload, uint32_t paylen, char* key, uint32_t keylen, int32_t partition, uint64_t* msgid, char* errtxt, int *plen);
 
 	LIBRARY_API int Consume(void* cons, char* topic, uint32_t* topiclen, char* payload, uint32_t* paylen, char* key, uint32_t* keylen, int32_t* partition, char* errtxt, int *plen);
-	LIBRARY_API int Commit(void* cons, void* subscr, int* async);
+	LIBRARY_API int Commit(void* cons, void* subscr, int32_t async);
 
 	LIBRARY_API int DeliveryReport(void* prod, unsigned long long* msgid, int* err, int* plength);
 	LIBRARY_API int DRMessageError(int* err, char* errtxt, int *plen);

--- a/kafka/kafka.h
+++ b/kafka/kafka.h
@@ -52,7 +52,7 @@ extern "C"
 	LIBRARY_API int Produce(void* prod, char* topic, char* payload, uint32_t paylen, char* key, uint32_t keylen, int32_t partition, uint64_t* msgid, char* errtxt, int *plen);
 
 	LIBRARY_API int Consume(void* cons, char* topic, uint32_t* topiclen, char* payload, uint32_t* paylen, char* key, uint32_t* keylen, int32_t* partition, char* errtxt, int *plen);
-	LIBRARY_API int Commit(void* cons, void* subscr, int32_t async);
+	LIBRARY_API int Commit(void* cons, void* subscr);
 
 	LIBRARY_API int DeliveryReport(void* prod, unsigned long long* msgid, int* err, int* plength);
 	LIBRARY_API int DRMessageError(int* err, char* errtxt, int *plen);

--- a/kafka/kafka.h
+++ b/kafka/kafka.h
@@ -51,6 +51,7 @@ extern "C"
 	LIBRARY_API int Produce(void* prod, char* topic, char* payload, uint32_t paylen, char* key, uint32_t keylen, int32_t partition, uint64_t* msgid, char* errtxt, int *plen);
 
 	LIBRARY_API int Consume(void* cons, char* topic, uint32_t* topiclen, char* payload, uint32_t* paylen, char* key, uint32_t* keylen, int32_t* partition, char* errtxt, int *plen);
+	LIBRARY_API int Commit(void* cons, void* subscr, int* async);
 
 	LIBRARY_API int DeliveryReport(void* prod, unsigned long long* msgid, int* err, int* plength);
 	LIBRARY_API int DRMessageError(int* err, char* errtxt, int *plen);


### PR DESCRIPTION
Changes:
- cpp:
  - Commit - exposing `rd_kafka_commit`: manually commit offsets. 
  - SetTopicPartitionList - exposing `rd_kafka_topic_partition_list_add`: has been modified to allow specifying also the partition id (previously, it was used only when subscribing the consumer to a topic list, for which the partition argument is ignored and therefore set to 0).
   - SetOffset - exposing `rd_kafka_topic_partition_list_set_offset`: provided a `rd_kafka_topic_partition_list_t`, a topic, a partition, and an offset, this function set the offset.

- APL:
  - kafka.commit
  - kafka.set_offset: return an error if the specified combination of topic and partition does not exists in the provided `rd_kafka_topic_partition_list_t`.

and in Consumer.aplc
  - set_topic_partition: has been modified to accept the partition id.
  - subscribe: has been modified to pass "0" as partition id.
  - set_offset
  - commit: at the moment commit **does not** take any argument: the topic partition list is 0 (which means "commit on all the subscribed topic/partition") and asynch is 0 (which translate to "commit synch").

To test manual commit offsets on a specific combination of topic and partition, modify the `commit` function in Consumer.aplc to 
```
    ∇ r←commit tplist
      :Access public
      r←kafka.commit cons tplist 0
    ∇
```
then:
`tp_to_commit←consumer.topic_partition`
`consumer.set_topic_partition(tp_to_commit, 'topic' p)` 
(can add other topics or partitions calling again `consumer.set_topic_partition`)
will create a new topic partition list with 'topic'(s) and partition "p"
`consumer.set_offset(tp_to_commit, 'topic' p offset)`
will set the offset "offset" for the specified 'topic' and partition "p".
`consumer.commit tp_to_commit`
will commit to that offest.