### PR TITLE
Add error handling when ⎕EX producer and consumer.

### DIFF
--- a/aplsource/Consumer.aplc
+++ b/aplsource/Consumer.aplc
@@ -38,9 +38,9 @@
     ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝
     ⍝ Destructor
 
-    ∇ unmake
+    ∇ unmake;_
       :Implements destructor
-      kafka.UninitConsumer cons
+      _←kafka.UninitConsumer cons
     ∇
 
     ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝

--- a/aplsource/Producer.aplc
+++ b/aplsource/Producer.aplc
@@ -26,9 +26,9 @@
 
     ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝
     ⍝ Destructor
-    ∇ unmake
+    ∇ unmake;_
       :Implements destructor
-      kafka.UninitProducer prod
+      _←kafka.UninitProducer prod
     ∇
 
     ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝

--- a/kafka/kafka.cpp
+++ b/kafka/kafka.cpp
@@ -88,28 +88,29 @@ LIBRARY_API int InitKafka(void** kafka)
 LIBRARY_API int UninitProducer(void* prod)
 {
 	kafka_struct* pr = (kafka_struct*)prod;
-
+	int kerr = 0;
 	if (pr->rk != NULL) {
-		rd_kafka_flush((rd_kafka_t*)pr->rk, 500);
+		kerr = rd_kafka_flush((rd_kafka_t*)pr->rk, 500);
 		rd_kafka_destroy((rd_kafka_t*)pr->rk);
 	}
 	free(pr);
 
-	return 0;
+	return kerr;
 }
 
 LIBRARY_API int UninitConsumer(void* cons)
 {
 	kafka_struct* co = (kafka_struct*)cons;
+	int kerr = 0;
 	if (co->rk != NULL) {
 		// Close consumer
-		rd_kafka_consumer_close(co->rk);
+		kerr = rd_kafka_consumer_close(co->rk);
 		// Destroy the consumer.
 		rd_kafka_destroy(co->rk);
 	}
 	free(co);
 
-	return 0;
+	return kerr;
 }
 
 LIBRARY_API int SetKafkaConf(void* kafka, char* key, char* val, char* errtxt, int *plen)


### PR DESCRIPTION
When deleting a producer/consumer, an error is returned if the call fails (RD_KAFKA_RESP_ERR_NO_ERROR=0 otherwise):
- RD_KAFKA_RESP_ERR__TIMED_OUT when closing a producer (to test, start the producer, produce a message, then shut down the server, produce another message and try to ⎕ex the producer).
- an [rd_kafka_resp_err_t](https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#a03509bab51072c72a8dcf52337e6d5cb) error when closing the consumer (see the link for more details).