### PR TITLE
26 improving error msgs

### DIFF
--- a/aplsource/Producer.aplc
+++ b/aplsource/Producer.aplc
@@ -46,20 +46,22 @@
     (topic payload key partition)←4↑ arg,  (≢arg)↓ '' '' '' ¯1
       :Access public
       (z msgid err)←kafka.produce prod topic payload key partition
-      r←z,msgid
       :If z=0
-        outstanding⍪←msgid 0
+          outstanding⍪←msgid 0
+          r←z,msgid
+      :Else
+          :If 0≠⍴err
+              r←z,msgid,'ERROR START PRODUCER: ',err
+          :Else
+              r←z,msgid,'ERROR: ',2⊃parse_error z
+          :EndIf
       :EndIf
     ∇
 
 
     ∇ r←produce_record record;err;msgid;z
       :Access public
-      (z msgid err)←kafka.produce prod, record.asArg
-      r←z,msgid
-      :If z=0
-        outstanding⍪←msgid 0
-      :EndIf
+      r←produce record.asArg
     ∇
 
     ⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝⍝

--- a/aplsource/kafka/produce.aplf
+++ b/aplsource/kafka/produce.aplf
@@ -6,8 +6,4 @@
  ⍝ key key
  ⍝ partition partition
  (err msgid msg len)←4↑Produce prod topic_name payload(≢payload)key(≢key)partition 1 512 512
- :If 0≠len
-     r←err msgid (len↑msg)
- :Else
-     r←err msgid ''
- :EndIf
+ r←err msgid (len↑msg)

--- a/aplsource/kafka/produce.aplf
+++ b/aplsource/kafka/produce.aplf
@@ -6,8 +6,8 @@
  ⍝ key key
  ⍝ partition partition
  (err msgid msg len)←4↑Produce prod topic_name payload(≢payload)key(≢key)partition 1 512 512
- :if 0≠err
-    r←err msgid (len↑msg)
- :else
-    r←0 msgid ''
-:endif
+ :If 0≠len
+     r←err msgid (len↑msg)
+ :Else
+     r←err msgid ''
+ :EndIf

--- a/kafka/kafka.cpp
+++ b/kafka/kafka.cpp
@@ -158,9 +158,10 @@ LIBRARY_API int Produce(void* prod, char* topic,  char* payload, uint32_t paylen
 		pr->rk = rk;
 		if (NULL!=rk)
 			*plen = 0;
-		else
-			*plen =(int) strlen(errtxt);
-
+		else {
+			*plen = (int)strlen(errtxt);	
+			return 1;					// Failed to initialize producer
+		}
 		//ok?
 		pr->conf = NULL;
 	}

--- a/kafka/kafka.cpp
+++ b/kafka/kafka.cpp
@@ -143,6 +143,7 @@ LIBRARY_API int Produce(void* prod, char* topic,  char* payload, uint32_t paylen
 	*errtxt = 0;
 
 	kafka_struct* pr = (kafka_struct*)prod;
+	*msgid = global_counter++;
 
 	if (pr->rk == NULL) {
 
@@ -165,9 +166,6 @@ LIBRARY_API int Produce(void* prod, char* topic,  char* payload, uint32_t paylen
 		//ok?
 		pr->conf = NULL;
 	}
-
-	
-	*msgid = global_counter++;
 
 	kerr = rd_kafka_producev(pr->rk,
 		RD_KAFKA_V_PARTITION(partition),


### PR DESCRIPTION
Implementing #26, comment section.

- when failing to initialize producer via rd_kafka_new (e.g. when setting correct but incompatible configs such as enable.idempotence=true and acks=1):
    r←z,msgid,'ERROR START PRODUCER: ',err
In this case, err comes from rd_kafka_new and the Producer function will return 1 (z).
- when failing to produce with rd_kafka_producev:
  r←z,msgid,'ERROR: ',2⊃parse_error z
z is the error code and is converted to text by parse_error.

produce_record now calls produce instead of kafka.produce.